### PR TITLE
Capitalize Bitcoin where appropriate

### DIFF
--- a/wallets.asciidoc
+++ b/wallets.asciidoc
@@ -153,7 +153,7 @@ If you are implementing an Ethereum wallet, it should be built as a HD wallet, w
 ((("brainwallets")))Mnemonic words are often confused with "brainwallets." They are not the same. The primary difference is that a brainwallet consists of words chosen by the user, whereas mnemonic words are created randomly by the wallet and presented to the user. This important difference makes mnemonic words much more secure, because humans are very poor sources of randomness.
 ====
 
-Mnemonic codes are defined in BIP-39. Note that BIP-39 is one implementation of a mnemonic code standard. There is a different standard, _with a different set of words_, used by the Electrum bitcoin wallet and predating BIP-39. BIP-39 was proposed by the company behind the Trezor hardware wallet and is incompatible with Electrum's implementation. However, BIP-39 has now achieved broad industry support across dozens of interoperable implementations and should be considered the de-facto industry standard. Furthermore, BIP-39 can be used to produce multicurrency wallets supporting Ethereum, whereas Electrum seeds cannot.
+Mnemonic codes are defined in BIP-39. Note that BIP-39 is one implementation of a mnemonic code standard. There is a different standard, _with a different set of words_, used by the Electrum Bitcoin wallet and predating BIP-39. BIP-39 was proposed by the company behind the Trezor hardware wallet and is incompatible with Electrum's implementation. However, BIP-39 has now achieved broad industry support across dozens of interoperable implementations and should be considered the de-facto industry standard. Furthermore, BIP-39 can be used to produce multicurrency wallets supporting Ethereum, whereas Electrum seeds cannot.
 
 ////
 TODO: Make sure Electrum seeds are not usable for Ethereum
@@ -416,7 +416,7 @@ A few examples: Ethereum is m/44++&#x27;++/60++&#x27;++, Ethereum Classic is m/4
 
 The third level of the tree is "account," which allows users to subdivide their wallets into separate logical subaccounts, for accounting or organizational purposes. For example, an HD wallet might contain two Ethereum "accounts": m/44++&#x27;++/60++&#x27;++/0++&#x27;++ and m/44++&#x27;++/60++&#x27;++/1++&#x27;++. Each account is the root of its own subtree.
 
-((("keys and addresses", see="also public and private keys")))Because BIP-44 was created originally for bitcoin, it contains a "quirk" that isn't relevant in the Ethereum world. On the fourth level of the path, "change," an HD wallet has two subtrees, one for creating receiving addresses and one for creating change addresses. Only the "receive" path is used in Ethereum, as there is no such thing as a change address. Note that whereas the previous levels used hardened derivation, this level uses normal derivation. This is to allow this level of the tree to export extended public keys for use in a non-secured environment. Usable addresses are derived by the HD wallet as children of the fourth level, making the fifth level of the tree the "address_index." For example, the third receiving address for Ethereum payments in the primary account would be M/44++&#x27;++/60++&#x27;++/0++&#x27;++/0/2. <<bip44_path_examples>> shows a few more examples.
+((("keys and addresses", see="also public and private keys")))Because BIP-44 was created originally for Bitcoin, it contains a "quirk" that isn't relevant in the Ethereum world. On the fourth level of the path, "change," an HD wallet has two subtrees, one for creating receiving addresses and one for creating change addresses. Only the "receive" path is used in Ethereum, as there is no such thing as a change address. Note that whereas the previous levels used hardened derivation, this level uses normal derivation. This is to allow this level of the tree to export extended public keys for use in a non-secured environment. Usable addresses are derived by the HD wallet as children of the fourth level, making the fifth level of the tree the "address_index." For example, the third receiving address for Ethereum payments in the primary account would be M/44++&#x27;++/60++&#x27;++/0++&#x27;++/0/2. <<bip44_path_examples>> shows a few more examples.
 
 [[bip44_path_examples]]
 .BIP-44 HD wallet structure examples
@@ -424,6 +424,6 @@ The third level of the tree is "account," which allows users to subdivide their 
 |=======
 |HD path | Key described
 | M/44++&#x27;++/60++&#x27;++/0++&#x27;++/0/2 | The third receiving public key for the primary Ethereum account
-| M/44++&#x27;++/0++&#x27;++/3++&#x27;++/1/14 | The fifteenth change-address public key for the fourth bitcoin account
+| M/44++&#x27;++/0++&#x27;++/3++&#x27;++/1/14 | The fifteenth change-address public key for the fourth Bitcoin account
 | m/44++&#x27;++/2++&#x27;++/0++&#x27;++/0/1 | The second private key in the Litecoin main account, for signing transactions
 |=======


### PR DESCRIPTION
https://bitcoin.org/en/vocabulary#bitcoin
> Bitcoin - with capitalization, is used when describing the concept of Bitcoin, or the entire network itself. e.g. "I was learning about the Bitcoin protocol today."
> 
> bitcoin - without capitalization, is used to describe bitcoins as a unit of account. e.g. "I sent ten bitcoins today."; it is also often abbreviated BTC or XBT.